### PR TITLE
Unnecessary array copying in katz_centrality_numpy ?

### DIFF
--- a/networkx/algorithms/centrality/katz.py
+++ b/networkx/algorithms/centrality/katz.py
@@ -327,7 +327,7 @@ def katz_centrality_numpy(G, alpha=0.1, beta=1.0, normalized=True,
             raise nx.NetworkXError('beta must be a number')
 
     A = nx.adj_matrix(G, nodelist=nodelist, weight=weight).todense().T
-    n = np.array(A).shape[0]
+    n = A.shape[0]
     centrality = np.linalg.solve( np.eye(n,n) - (alpha * A) , b)
     if normalized:
         norm = np.sign(sum(centrality)) * np.linalg.norm(centrality)


### PR DESCRIPTION
Consider the following code in `networkx/algorithms/centrality/katz.py` :

``` python
A = nx.adj_matrix(G, nodelist=nodelist, weight=weight).todense().T
n = np.array(A).shape[0]
```

From the [numpy.array()](http://docs.scipy.org/doc/numpy/reference/generated/numpy.array.html) documentation, `np.array(A)` does make a copy in memory. Removing the call to `np.array()` should work the same without using up extra memory just to see the shape of `A`.
